### PR TITLE
Load more articles

### DIFF
--- a/src/containers/pages/ArticlesPage/ArticlesPage.js
+++ b/src/containers/pages/ArticlesPage/ArticlesPage.js
@@ -46,7 +46,7 @@ export class ArticlesPage extends Component {
   }
 
   componentWillMount() {
-    this.props.loadEntities({ href: '/bookmarks', type: ARTICLES_VIEW_STATE, schema: arrayOf(articleSchema) });
+    this.props.loadEntities({ href: '/bookmarks?per_page=200', type: ARTICLES_VIEW_STATE, schema: arrayOf(articleSchema) });
   }
 
   onRowSelection(selectedRows) {


### PR DESCRIPTION
Problem: I have about 25 articles, but frontend show only 20 first.

Solution: Request more articles from the backend. While this is a
workaround and not real solution, it resolves the issue.