### PR TITLE
Select a row only by clicking on checkbox; better styles for links.

### DIFF
--- a/src/components/ArticlesTable/ArticlesTable.js
+++ b/src/components/ArticlesTable/ArticlesTable.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-no-bind */
+
 import Immutable from 'immutable';
 import moment from 'moment';
 import { Component, PropTypes } from 'react';
@@ -74,10 +76,15 @@ export class ArticlesTable extends Component {
               key={i}
               selected={this.props.selectedRows.indexOf(i) !== MINUS_ONE}
             >
-              <TableRowColumn style={inlineStyles.wrapWordColumn}>
-                <div className={styles.linkDiv}>
+              <TableRowColumn
+                className={styles.preventCellClick}
+                style={inlineStyles.wrapWordColumn}
+              >
+                <div
+                  className={styles.linkDiv}
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <a
-                    className={styles.link}
                     href={item.get('url')}
                     target="_blank"
                   >
@@ -85,8 +92,22 @@ export class ArticlesTable extends Component {
                   </a>
                 </div>
               </TableRowColumn>
-              <TableRowColumn>{moment(item.get('timestamp')).format('lll')}</TableRowColumn>
-              <TableRowColumn>{item.get('read') ? moment(item.get('read')).format('lll') : 'No'}</TableRowColumn>
+              <TableRowColumn className={styles.preventCellClick}>
+                <div
+                  className={styles.preventCellClickWrapper}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {moment(item.get('timestamp')).format('lll')}
+                </div>
+              </TableRowColumn>
+              <TableRowColumn className={styles.preventCellClick}>
+                <div
+                  className={styles.preventCellClickWrapper}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {item.get('read') ? moment(item.get('read')).format('lll') : 'No'}
+                </div>
+              </TableRowColumn>
             </TableRow>
           );
         })}

--- a/src/components/ArticlesTable/ArticlesTable.less
+++ b/src/components/ArticlesTable/ArticlesTable.less
@@ -1,22 +1,26 @@
 .linkDiv {
-  a {
-    transition: color 0.4s;
-    color: #265c83;
+  a:link {
+    color: #008ace;
+    text-decoration: none;
   }
-
-  a:link,
   a:visited {
-    color: #265c83;
+    color: #b40eb4;
+    text-decoration: none;
   }
   a:hover {
-    color: #7fdbff;
-  }
-  a:active {
-    transition: color 0.3s;
-    color: #007be6;
+    text-decoration: underline;
   }
 }
 
-.link {
-  text-decoration: none;
+.preventCellClick {
+  position: relative;
+}
+
+.preventCellClickWrapper::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
 }


### PR DESCRIPTION
This patch a workaround for “selecting a row only by clicking on checkbox”
problem (see https://github.com/callemall/material-ui/issues/3453).
And it's still possible to select a row if you click on empty space
in title column but it's much better than current behavior.

This patch also enhances styles for links in the table.