### PR TITLE
Fix math of calculating perPage param

### DIFF
--- a/src/containers/pages/ArticlesPage/ArticlesPage.js
+++ b/src/containers/pages/ArticlesPage/ArticlesPage.js
@@ -41,7 +41,7 @@ export class ArticlesPage extends Component {
 
     this.state = {
       currentArticles: Immutable.fromJS([]),
-      pageSize: 30,
+      pageSize: Math.min(MAX_PER_PAGE, 30), // eslint-disable-line
       selectedRows: [],
       total: 1,
     };
@@ -71,12 +71,14 @@ export class ArticlesPage extends Component {
       return;
     }
 
-    const total = parseInt(last.get('per_page'), 10) * parseInt(last.get('page'), 10);
+    const pageLast = parseInt(last.get('page'), 10);
+    const perPageLast = parseInt(last.get('per_page'), 10);
+    const total = pageLast * perPageLast;
 
     this.setState({ total });
 
-    const numberOfRequests = Math.ceil(total / MAX_PER_PAGE);
-    const perPage = Math.min(total, MAX_PER_PAGE);
+    const perPage = Math.trunc(Math.min(MAX_PER_PAGE, total) / perPageLast) * perPageLast;
+    const numberOfRequests = Math.ceil(total / perPage);
 
     [...Array(numberOfRequests).keys()].reduce((seq, i) => {
       const page = i + ONE;
@@ -87,10 +89,7 @@ export class ArticlesPage extends Component {
         schema: arrayOf(articleSchema),
         resetState: page === ONE,
       }));
-    }, Promise.resolve()).then(
-      () => console.log('ArticlesPage: all articles are loaded.'),
-      (e) => console.log('ArticlesPage: ', e),
-    );
+    }, Promise.resolve());
   }
 
   handleOnExport() {


### PR DESCRIPTION
_Let me try to explain the issue..._

_Input:_
---
• `MAX_PER_PAGE = 50` − maximum value which server allows to get per page
• we want to show `20` articles per page
• we have `42` articles on the server

_Previous code of loading articles:_
---
```js
const total = parseInt(last.get('per_page'), 10) * parseInt(last.get('page'), 10); // 20 * 3 ⇒ 60
const numberOfRequests = Math.ceil(total / MAX_PER_PAGE); // ceil(60 / 50) ⇒ 2
const perPage = Math.min(total, MAX_PER_PAGE); // min(60, 50) ⇒ 50
```
Then we make the `2` requests to the server with `perPage = 50` and `page = 1` and `page = 2` params.

**Output:** 
the second request returns `404` http code since we have only `42` articles and we asked for `50` articles on the `2` page

_Current code of loading articles:_
---
```js
const pageLast = parseInt(last.get('page'), 10); // 3
const perPageLast = parseInt(last.get('per_page'), 10); // 20
const total = pageLast * perPageLast; // 60
  
// Math.trunc(Math.min(60, 50) / 20) * 20 ⇒ Math.trunc(50 / 20) * 20 ⇒ 2 * 20 ⇒ 40
const perPage = Math.trunc(Math.min(MAX_PER_PAGE, total) / perPageLast) * perPageLast;
// Math.ceil(60 / 40) ⇒ 2
const numberOfRequests = Math.ceil(total / perPage);
```
Then we make the `2` requests to the server with `perPage = 40` and `page = 1` and `page = 2` params.

**Output:** 
all articles are loaded successfully 


