### PR TITLE
Don't deselect rows after importing/exporting.

### DIFF
--- a/src/components/ImportModal/ImportModal.js
+++ b/src/components/ImportModal/ImportModal.js
@@ -55,9 +55,6 @@ export class ImportModal extends Component {
     if (!articlesToImport.isEmpty()) {
       this.props.rememberArticles({ articles: articlesToImport });
     }
-
-    // unselect all (only works if you selected each row separately, see https://github.com/callemall/material-ui/issues/3074)
-    this.state = { selectedRows: [] };
   }
 
   handleClose() {

--- a/src/containers/pages/ArticlesPage/ArticlesPage.js
+++ b/src/containers/pages/ArticlesPage/ArticlesPage.js
@@ -112,9 +112,6 @@ export class ArticlesPage extends Component {
     } else {
       tempLink.click();
     }
-
-    // unselect all (only works if you selected each row separately, see https://github.com/callemall/material-ui/issues/3074)
-    this.setState({ selectedRows: [] });
   }
 
   handleOnPageChange(selectedPage) {


### PR DESCRIPTION
Problem: I think there is a bug in Material UI table in “selecting all”
feature: it's not possible to reset all rows programmatically. Anyway they
won't fix this bug since they ported table to the [next](https://github.com/callemall/material-ui/blob/master/ROADMAP.md) branch.

Solution: don't unselect rows after importing/exporting.