### PR TITLE
Build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 script:
 - npm run lint
 - npm run test:unit
+- npm run build
 deploy:
   provider: s3
   access_key_id: AKIAJZKGISUSSVVUB7YQ


### PR DESCRIPTION
Problem:
```
/home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/s3.rb:47:in `chdir': No such file or directory @ dir_chdir - dist (Errno::ENOENT)
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/s3.rb:47:in `push_app'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider.rb:146:in `block in deploy'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/cli.rb:41:in `fold'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider.rb:146:in `deploy'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/provider/s3.rb:75:in `deploy'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/cli.rb:32:in `run'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/lib/dpl/cli.rb:7:in `run'
	from /home/travis/.rvm/gems/ruby-2.2.5/gems/dpl-1.8.31/bin/dpl:5:in `<top (required)>'
	from /home/travis/.rvm/gems/ruby-2.2.5/bin/dpl:23:in `load'
	from /home/travis/.rvm/gems/ruby-2.2.5/bin/dpl:23:in `<main>'
failed to deploy
```

We deploy `dist` directory, but haven't built the frontend before.

Solution: build the frontend before deploying.