### PR TITLE
Integrate redux-logger with Immutable

### DIFF
--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -1,6 +1,7 @@
 import { applyMiddleware, compose, createStore } from 'redux';
 import createLogger from 'redux-logger';
 import createSagaMiddleware from 'redux-saga';
+import Immutable from 'immutable';
 
 import { basicMiddleware, middlewaresToApply } from './commonMiddlewares';
 
@@ -14,7 +15,14 @@ export default function configureStore(preloadedState) {
     ...basicMiddleware,
     preloadedState,
     compose(
-      applyMiddleware(...middlewaresToApply, sagaMiddleware, createLogger()),
+      applyMiddleware(
+        ...middlewaresToApply,
+        sagaMiddleware,
+        createLogger({
+          stateTransformer: (state) => state.toJS(),
+          // because toJS() is deep
+          actionTransformer: (action) => Immutable.fromJS(action).toJS(),
+        })),
       DevTools.instrument()
     )
   );


### PR DESCRIPTION
Problem: redux-logger output is hard to use because Immutable
structures are inconvenient to browse.

Solution: convert Immutable structures to plain javascript objects
before logging.