### PR TITLE
Improve 404 page by adding goto main link

### DIFF
--- a/src/components/NotFound/NotFound.js
+++ b/src/components/NotFound/NotFound.js
@@ -1,9 +1,39 @@
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { replace } from 'react-router-redux';
+import pureRender from 'pure-render-decorator';
 import styles from './NotFound.less';
 
-const NotFound = () =>
-  <div className={styles.notFound}>
-    <h3>{'404 page not found'}</h3>
-    <p>{'We are sorry but the page you are looking for does not exist.'}</p>
-  </div>;
+@pureRender
+class NotFound extends Component {
+  static propTypes = {
+    replaceUrl: PropTypes.func,
+  }
 
-export default NotFound;
+  constructor(props) {
+    super(props);
+
+    this.handleGotoMainClicked = this.handleGotoMainClicked.bind(this);
+  }
+
+  handleGotoMainClicked(e) {
+    e.preventDefault();
+    this.props.replaceUrl('/');
+  }
+
+  render() {
+    return (
+      <div className={styles.notFound}>
+        <h3>{'404 Page not found'}</h3>
+        <p>{'We are sorry but the page you are looking for does not exist.'}</p>
+        <a
+          href="/"
+          onClick={this.handleGotoMainClicked}
+        >
+          {'Go to main page'}
+        </a>
+      </div>);
+  }
+}
+
+export default connect(null, { replaceUrl: replace })(NotFound);


### PR DESCRIPTION
Problem: 404 is not very user friendly because it doesn't suggest a
way to correct the issue.

Solution: add "go to main page" link, which brings application back
into usable state.