### PR TITLE
Don't set isEditing to true on click if we're already editing

### DIFF
--- a/src/components/ArticlesTable/ArticleTitle.js
+++ b/src/components/ArticlesTable/ArticleTitle.js
@@ -37,6 +37,10 @@ export class ArticleTitle extends Component {
   }
 
   handleClick(e) {
+    if (this.state.isEditing) {
+      return;
+    }
+
     this.setState({
       isEditing: true,
       newValue: this.props.title,


### PR DESCRIPTION
Problem: click inside textinput resets all changes