### PR TITLE
Drop leading @ from tags on editing

### DIFF
--- a/src/components/ArticlesList/ArticleEditDialog.js
+++ b/src/components/ArticlesList/ArticleEditDialog.js
@@ -22,7 +22,7 @@ const stateToArticle = (state) => {
   return {
     title: state.title,
     url: state.url,
-    tags: preTags === '' ? [] : preTags.split(/[,\s]+/),
+    tags: preTags === '' ? [] : preTags.split(/[,\s]+/).map((x) => x.replace(/^@/, '')),
   };
 };
 


### PR DESCRIPTION
I accidentally entered `@tag` which actually created `@tag` that got
displayed as `@@tag`.

Drop leading `@` so `@tag` is saved as `tag`.