### PR TITLE
Initialize gapi.auth2 before sign out

### DIFF
--- a/src/actions/users.js
+++ b/src/actions/users.js
@@ -61,7 +61,13 @@ export const googleSignIn = (param) => (dispatch) => dispatch(doGoogleSignIn(par
 export const USER_LOGOUT = 'USER_LOGOUT';
 
 export const logoutUser = () => (dispatch) => {
-  // eslint-disable-next-line no-undef
-  gapi.auth2.getAuthInstance().signOut().then(() =>
-    dispatch({ type: USER_LOGOUT }));
+  /* eslint-disable no-undef */
+  if (!gapi.auth2) {
+    gapi.load('client:auth2', () =>
+      gapi.auth2.init().then(() => logoutUser()(dispatch)));
+  } else {
+    gapi.auth2.getAuthInstance().signOut().then(() =>
+      dispatch({ type: USER_LOGOUT }));
+  }
+  /* eslint-enable no-undef */
 };


### PR DESCRIPTION
This fixes the following error:

```
users.js?13ee:65
Uncaught TypeError: Cannot read property 'getAuthInstance' of undefined
    at eval (users.js?13ee:65)
    at eval (index.js?f248:11)
    at Object.eval [as logoutUser] (bindActionCreators.js?3d4a:3)
    at HeaderBar.handleLogout (HeaderBar.js?fb00:86)
    at HeaderBar.handleLogout (createPrototypeProxy.js?2c5c:44)
    at EnhancedButton._this.handleTouchTap (EnhancedButton.js?7315:149)
    at HTMLUnknownElement.boundFunc (ReactErrorUtils.js?dc41:63)
    at Object.ReactErrorUtils.invokeGuardedCallback (ReactErrorUtils.js?dc41:69)
    at executeDispatch (EventPluginUtils.js?5d8c:83)
    at Object.executeDispatchesInOrder (EventPluginUtils.js?5d8c:106)
```